### PR TITLE
Use path.href instead of path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ var organize = function( options )
         _.each( filteredFiles, function(item)
         {
             // Split the path by directories into an array
-            var pathParts = item.path.split( "/" );
+            var pathParts = item.path.href.split( "/" );
 
             // Last item is the "file.ext" part. Remove it
             pathParts.pop();


### PR DESCRIPTION
I'm assuming metalsmith has been updated and `item.path` is no longer a string. `item.path.href` seems to be a drop-in replacement for the previous `item.path` string.